### PR TITLE
Add interval to coin market chart parameters

### DIFF
--- a/coins.go
+++ b/coins.go
@@ -121,11 +121,14 @@ func (c *Client) CoinsIdHistory(id, date string, localization bool) (*coins.Hist
 	return data, nil
 }
 
-func (c *Client) CoinsIdMarketChart(id, currency, days string) (*types.MarketChart, error) {
+func (c *Client) CoinsIdMarketChart(id, currency, days, interval string) (*types.MarketChart, error) {
 	params := url.Values{}
 	params.Add("vs_currency", currency)
 	params.Add("days", days)
-	params.Add("interval", "daily")
+
+	if interval != "" {
+		params.Add("interval", interval)
+	}
 
 	rUrl := fmt.Sprintf("%s/%s/%s?%s", c.getCoinsURL(), id, "market_chart", params.Encode())
 	resp, err := c.MakeReq(rUrl)

--- a/test/coins_test.go
+++ b/test/coins_test.go
@@ -76,7 +76,7 @@ func TestCoinsIdsMarketChart(t *testing.T) {
 
 	cgClient := goingecko.NewClient(nil, "")
 
-	coinData, err := cgClient.CoinsIdMarketChart("bitcoin", "usd", "10")
+	coinData, err := cgClient.CoinsIdMarketChart("bitcoin", "usd", "10", "daily")
 	if coinData == nil {
 		t.Errorf("Error")
 	}


### PR DESCRIPTION
Adds interval parameter for the coin market charts endpoint.
This changes the default from `daily` to empty, which allows the API to [automatically choose the granularity](https://docs.coingecko.com/reference/coins-id-market-chart#:~:text=You%20may%20leave%20the%20interval%20params%20as%20empty%20for%20automatic%20granularity).