### PR TITLE
Update: use int64 and float64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * [#39](https://github.com/JulianToledano/goingecko/pull/39) Change CodeStats types from int16 to int64.
+* [#41](https://github.com/JulianToledano/goingecko/pull/41) Use int64 and float64 in all types.
 
 ## [v3.0.0](https://github.com/JulianToledano/goingecko/releases/tag/v3.0.0) - 2025.01-25
 

--- a/api/coins/types/id.go
+++ b/api/coins/types/id.go
@@ -7,7 +7,7 @@ type CoinID struct {
 	Symbol             string   `json:"symbol"`
 	Name               string   `json:"name"`
 	AssetPlatformID    string   `json:"asset_platform_id"`
-	BlockTimeInMinutes int      `json:"block_time_in_minutes"`
+	BlockTimeInMinutes int64    `json:"block_time_in_minutes"`
 	HashingAlgorithm   string   `json:"hashing_algorithm"`
 	Categories         []string `json:"categories"`
 	// PublicNotice ¿? `json:"public_notice"`
@@ -18,15 +18,15 @@ type CoinID struct {
 	Image                     types.Image               `json:"image"`
 	CountryOrigin             string                    `json:"country_origin"`
 	GenesisData               string                    `json:"genesis_date"`
-	SentimentVotesUpPercent   float32                   `json:"sentiment_votes_up_percentage"`
-	SentimentVotesDownPercent float32                   `json:"sentiment_votes_down_percentage"`
-	MarketCapRank             int                       `json:"market_cap_rank"`
-	CoingeckoRank             int                       `json:"coingecko_rank"`
-	CoingeckoScore            float32                   `json:"coingecko_score"`
-	DeveloperScore            float32                   `json:"developer_score"`
-	CommunityScore            float32                   `json:"community_score"`
-	LiquidityScore            float32                   `json:"liquidity_score"`
-	PublicInterestScore       float32                   `json:"public_interest_score"`
+	SentimentVotesUpPercent   float64                   `json:"sentiment_votes_up_percentage"`
+	SentimentVotesDownPercent float64                   `json:"sentiment_votes_down_percentage"`
+	MarketCapRank             int64                     `json:"market_cap_rank"`
+	CoingeckoRank             int64                     `json:"coingecko_rank"`
+	CoingeckoScore            float64                   `json:"coingecko_score"`
+	DeveloperScore            float64                   `json:"developer_score"`
+	CommunityScore            float64                   `json:"community_score"`
+	LiquidityScore            float64                   `json:"liquidity_score"`
+	PublicInterestScore       float64                   `json:"public_interest_score"`
 	MarketData                types.MarketData          `json:"market_data"`
 	CommunityData             types.CommunityData       `json:"community_data"`
 	DeveloperData             types.DeveloperData       `json:"developer_data"`

--- a/api/coins/types/markets.go
+++ b/api/coins/types/markets.go
@@ -9,7 +9,7 @@ type Market struct {
 	Image                                      string          `json:"image"`
 	CurrentPrice                               float64         `json:"current_price"`
 	MarketCap                                  float64         `json:"market_cap"`
-	MarkeCcapRank                              int32           `json:"market_cap_rank"`
+	MarkeCcapRank                              int64           `json:"market_cap_rank"`
 	FullyDilutedValuation                      float64         `json:"fully_diluted_valuation"`
 	TotalVolume                                float64         `json:"total_volume"`
 	HighDay                                    float64         `json:"high_24h"`

--- a/api/contract/types/contractAddress.go
+++ b/api/contract/types/contractAddress.go
@@ -9,7 +9,7 @@ type ContractAddressInfo struct {
 	Name               string            `json:"name"`
 	AssetPlatformId    string            `json:"asset_platform_id"`
 	Platforms          map[string]string `json:"platforms"`
-	BlockTimeInMinutes int               `json:"block_time_in_minutes"`
+	BlockTimeInMinutes int64             `json:"block_time_in_minutes"`
 	Hashing_algorithm  string            `json:"hashing_algorithm"`
 	Categories         []string          `json:"categories"`
 	// public_notice `json:"//`"
@@ -24,8 +24,8 @@ type ContractAddressInfo struct {
 	Sentiment_votes_up_percentage   float64                   `json:"sentiment_votes_up_percentage"`
 	Sentiment_votes_down_percentage float64                   `json:"sentiment_votes_down_percentage"`
 	IcoData                         IcoData                   `json:"ico_data"`
-	MarketCapRank                   int32                     `json:"market_cap_rank"`
-	CoingeckoRank                   int32                     `json:"coingecko_rank"`
+	MarketCapRank                   int64                     `json:"market_cap_rank"`
+	CoingeckoRank                   int64                     `json:"coingecko_rank"`
 	CoingeckoScore                  float64                   `json:"coingecko_score"`
 	DeveloperScore                  float64                   `json:"developer_score"`
 	CommunityScore                  float64                   `json:"community_score"`

--- a/api/derivatives/types/derivatives.go
+++ b/api/derivatives/types/derivatives.go
@@ -22,10 +22,10 @@ type Exchange struct {
 	ID                     string  `json:"id"`
 	OpenInterestBtc        float64 `json:"open_interest_btc"`
 	TradeVolume24hBtc      string  `json:"trade_volume_24h_btc"`
-	NumberOfPerpetualPairs int32   `json:"number_of_perpetual_pairs"`
-	NumberOfFuturesPairs   int32   `json:"number_of_futures_pairs"`
+	NumberOfPerpetualPairs int64   `json:"number_of_perpetual_pairs"`
+	NumberOfFuturesPairs   int64   `json:"number_of_futures_pairs"`
 	Image                  string  `json:"image"`
-	YearEstablished        int32   `json:"year_established"`
+	YearEstablished        int64   `json:"year_established"`
 	Country                string  `json:"country"`
 	Description            string  `json:"description"`
 	Url                    string  `json:"url"`
@@ -38,7 +38,7 @@ type ExchangeId struct {
 	NumberOfPerpetualPairs int64    `json:"number_of_perpetual_pairs"`
 	NumberOfPuturesPairs   int64    `json:"number_of_futures_pairs"`
 	Image                  string   `json:"image"`
-	YearEstablished        int32    `json:"year_established"`
+	YearEstablished        int64    `json:"year_established"`
 	Country                string   `json:"country"`
 	Description            string   `json:"description"`
 	Url                    string   `json:"url"`

--- a/api/exchanges/types/exchanges.go
+++ b/api/exchanges/types/exchanges.go
@@ -3,14 +3,14 @@ package types
 type Exchange struct {
 	ID                         string  `json:"id"`
 	Name                       string  `json:"name"`
-	YearEstablished            int32   `json:"year_established"`
+	YearEstablished            int64   `json:"year_established"`
 	Country                    string  `json:"country"`
 	Description                string  `json:"description"`
 	Url                        string  `json:"url"`
 	Image                      string  `json:"image"`
 	HasTradingIncentive        bool    `json:"has_trading_incentive"`
-	TrustScore                 int32   `json:"trust_score"`
-	TrustScoreRank             int32   `json:"trust_score_rank"`
+	TrustScore                 int64   `json:"trust_score"`
+	TrustScoreRank             int64   `json:"trust_score_rank"`
 	TradeVolume24h             float64 `json:"trade_volume_24h_btc"`
 	TradeVolume24jBtcNormalice float64 `json:"trade_volume_24h_btc_normalized"`
 }
@@ -24,7 +24,7 @@ type ExchangeId struct {
 
 type ExchangeWithTicker struct {
 	Name                        string          `json:"name"`
-	YearEstablished             int32           `json:"year_established"`
+	YearEstablished             int64           `json:"year_established"`
 	Country                     string          `json:"country"`
 	Description                 string          `json:"description"`
 	Url                         string          `json:"url"`
@@ -40,8 +40,8 @@ type ExchangeWithTicker struct {
 	Centralized                 bool            `json:"centralized"`
 	PublicNotice                string          `json:"public_notice"`
 	AlertNotice                 string          `json:"alert_notice"`
-	TrustScore                  int32           `json:"trust_score"`
-	TrustScoreRank              int32           `json:"trust_score_rank"`
+	TrustScore                  int64           `json:"trust_score"`
+	TrustScoreRank              int64           `json:"trust_score_rank"`
 	TradeVolume24hBtc           float64         `json:"trade_volume_24h_btc"`
 	TradeVolume24hBtcNormalized float64         `json:"trade_volume_24h_btc_normalized"`
 	Tickers                     []Ticker        `json:"tickers"`

--- a/api/global/types/global.go
+++ b/api/global/types/global.go
@@ -7,11 +7,11 @@ type Global struct {
 }
 
 type data struct {
-	ActiveCryptocurrencies          int32              `json:"active_cryptocurrencies"`
-	UpcomingIcos                    int32              `json:"upcoming_icos"`
-	OngoingIcos                     int32              `json:"ongoing_icos"`
-	EndedIcos                       int32              `json:"ended_icos"`
-	Markets                         int32              `json:"markets"`
+	ActiveCryptocurrencies          int64              `json:"active_cryptocurrencies"`
+	UpcomingIcos                    int64              `json:"upcoming_icos"`
+	OngoingIcos                     int64              `json:"ongoing_icos"`
+	EndedIcos                       int64              `json:"ended_icos"`
+	Markets                         int64              `json:"markets"`
 	TotalMarketCap                  types.PriceRates   `json:"total_market_cap"`
 	TotalVolume                     types.PriceRates   `json:"total_volume"`
 	MarketCapPercentage             map[string]float64 `json:"market_cap_percentage"`

--- a/api/trending/types/trending.go
+++ b/api/trending/types/trending.go
@@ -12,7 +12,7 @@ type item struct {
 	ID            string  `json:"id"`
 	Name          string  `json:"name"`
 	Symbol        string  `json:"symbol"`
-	MarketCapRank int32   `json:"market_cap_rank"`
+	MarketCapRank int64   `json:"market_cap_rank"`
 	Thumb         string  `json:"thumb"`
 	Large         string  `json:"large"`
 	Score         float64 `json:"score"`

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -158,7 +158,7 @@ type MarketData struct {
 	AtlChangePercentage                   PriceRates `json:"atl_change_percentage"`
 	AtlDate                               DateRates  `json:"atl_date"`
 	MarketCap                             PriceRates `json:"market_cap"`
-	MarketCapRank                         int16      `json:"market_cap_rank"`
+	MarketCapRank                         int64      `json:"market_cap_rank"`
 	FullyDilutedValuation                 PriceRates `json:"fully_diluted_valuation"`
 	TotalVolume                           PriceRates `json:"total_volume"`
 	High24                                PriceRates `json:"high_24h"`


### PR DESCRIPTION
This PR updates all client/{endpoints}/types to use `int64`and `float64`