### PR TITLE
fix: endpoint for coins categories endpoint

### DIFF
--- a/api/categories/client.go
+++ b/api/categories/client.go
@@ -16,5 +16,5 @@ func NewClient(c *geckohttp.Client, url string) *CategoriesClient {
 }
 
 func (c *CategoriesClient) categoriesUrl() string {
-	return c.URL + "/categories"
+	return c.URL + "/coins/categories"
 }


### PR DESCRIPTION
Correct starting point for the categories endpoint is:
```
https://api.coingecko.com/api/v3/coins/categories
```

Ref: https://docs.coingecko.com/v3.0.1/reference/coins-categories-list